### PR TITLE
Fix: config.stub.dir not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ coverage/
 run/
 .DS_Store
 *.swp
+yarn.lock
 

--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ module.exports = app => {
 
     // load stub files and inject
     new app.loader.FileLoader({
-      directory: path.join(app.config.baseDir, 'app/stub'),
+      directory: app.config.stub.dir,
       call: false,
       caseStyle: 'lower',
       override: true,

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -12,7 +12,7 @@ module.exports = appInfo => {
    * @property {Object} mapping - stub target mapping
    */
   config.stub = {
-    dir: path.join(appInfo.baseDir, 'stub'),
+    dir: path.join(appInfo.baseDir, 'app/stub'),
     mapping: {
       service: 'serviceClasses',
       grpc: 'grpcClasses',

--- a/test/dir.test.js
+++ b/test/dir.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('assert');
+const mm = require('egg-mock');
+
+describe('test/dir.test.js', () => {
+  let app;
+  before(() => {
+    app = mm.app({
+      baseDir: 'apps/dir',
+    });
+    return app.ready();
+  });
+
+  after(() => app.close());
+  afterEach(mm.restore);
+
+  it('should support change dir', function* () {
+    const ctx = app.mockContext();
+
+    assert(!ctx.not);
+    assert(!ctx.service.not);
+    assert(!ctx.service.normal.not);
+
+    assert((yield ctx.service.clz.promise('a', 'b', 'c')) === 'stub clz promise: a,b,c');
+    assert((yield ctx.service.clz.generator('a', 'b', 'c')) === 'stub clz generator: a,b,c');
+    assert(ctx.service.clz.fn('a', 'b', 'c') === 'stub clz fn: a,b,c');
+
+    assert((yield ctx.service.clz.real('a', 'b', 'c')) === 'not override: a,b,c');
+    assert((yield ctx.service.clz.obj()) === 'origin obj');
+
+    assert((yield ctx.service.sub.deep.test.echo('a', 'b', 'c')) === 'stub deep: a,b,c');
+    assert((yield ctx.service.normal.echo('a', 'b', 'c')) === 'stub normal exports: a,b,c');
+    assert((yield ctx.service.normal.real('a', 'b', 'c')) === 'origin normal not override: a,b,c');
+
+    assert(ctx.service.fn.echo() === 'stub fn: example');
+
+    assert(ctx.service.mod.test() === 'stub mod + origin mod');
+  });
+});

--- a/test/fixtures/apps/dir/app/mocks/not/load.js
+++ b/test/fixtures/apps/dir/app/mocks/not/load.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.echo = () => Promise.resolve('should not load');

--- a/test/fixtures/apps/dir/app/mocks/service/clz.js
+++ b/test/fixtures/apps/dir/app/mocks/service/clz.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.promise = (...args) => Promise.resolve('stub clz promise: ' + args.join(','));
+
+exports.generator = function* (...args) { return 'stub clz generator: ' + args.join(','); };
+
+exports.fn = (...args) => 'stub clz fn: ' + args.join(',');
+
+exports.obj = {};

--- a/test/fixtures/apps/dir/app/mocks/service/fn.js
+++ b/test/fixtures/apps/dir/app/mocks/service/fn.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = app => {
+  return {
+    echo() {
+      return 'stub fn: ' + app.config.name;
+    },
+  };
+};

--- a/test/fixtures/apps/dir/app/mocks/service/mod.js
+++ b/test/fixtures/apps/dir/app/mocks/service/mod.js
@@ -1,0 +1,9 @@
+'use strict';
+module.exports = (app, clz) => {
+  class ModStubService extends clz {
+    test() {
+      return 'stub mod + ' + super.test();
+    }
+  }
+  return ModStubService;
+};

--- a/test/fixtures/apps/dir/app/mocks/service/normal.js
+++ b/test/fixtures/apps/dir/app/mocks/service/normal.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.echo = (...args) => Promise.resolve('stub normal exports: ' + args.join(','));
+
+exports.not = () => Promise.resolve('should not load');

--- a/test/fixtures/apps/dir/app/mocks/service/not.js
+++ b/test/fixtures/apps/dir/app/mocks/service/not.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.echo = () => Promise.resolve('should not load');

--- a/test/fixtures/apps/dir/app/mocks/service/sub/deep/test.js
+++ b/test/fixtures/apps/dir/app/mocks/service/sub/deep/test.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.echo = (...args) => Promise.resolve('stub deep: ' + args.join(','));

--- a/test/fixtures/apps/dir/app/service/clz.js
+++ b/test/fixtures/apps/dir/app/service/clz.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = app => {
+  class ClzService extends app.Service {
+    * generator() {
+      return 'origin clz';
+    }
+
+    promise() {
+      return Promise.resolve('origin clz');
+    }
+
+    fn() {
+      return 'origin clz';
+    }
+
+    * real(...args) {
+      return 'not override: ' + args.join(',');
+    }
+
+    * empty() {
+      return 'origin empty';
+    }
+
+    * obj() {
+      return 'origin obj';
+    }
+  }
+  return ClzService;
+};

--- a/test/fixtures/apps/dir/app/service/fn.js
+++ b/test/fixtures/apps/dir/app/service/fn.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.echo = () => 'origin fn';

--- a/test/fixtures/apps/dir/app/service/mod.js
+++ b/test/fixtures/apps/dir/app/service/mod.js
@@ -1,0 +1,9 @@
+'use strict';
+module.exports = app => {
+  class ModService extends app.Service {
+    test() {
+      return 'origin mod';
+    }
+  }
+  return ModService;
+};

--- a/test/fixtures/apps/dir/app/service/normal.js
+++ b/test/fixtures/apps/dir/app/service/normal.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.echo = (...args) => Promise.resolve('origin normal exports: ' + args.join(','));
+
+exports.real = function* (...args) { return 'origin normal not override: ' + args.join(','); };

--- a/test/fixtures/apps/dir/app/service/sub/deep/test.js
+++ b/test/fixtures/apps/dir/app/service/sub/deep/test.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.echo = (...args) => Promise.resolve('origin deep: ' + args.join(','));

--- a/test/fixtures/apps/dir/config/config.default.js
+++ b/test/fixtures/apps/dir/config/config.default.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = appInfo => {
+  const config = {};
+
+  config.keys = '123456';
+
+  config.stub = {
+    dir: path.join(appInfo.baseDir, 'app/mocks'),
+  };
+
+  return config;
+};

--- a/test/fixtures/apps/dir/package.json
+++ b/test/fixtures/apps/dir/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "example",
+  "version": "0.0.1"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

no

##### Description of change
<!-- Provide a description of the change below this comment. -->

It's not working when config.stub.dir changed, fixed it.